### PR TITLE
add install script

### DIFF
--- a/install
+++ b/install
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# List of LaTeX packages to install
+PACKAGES=(
+  polyglossia
+  fontspec
+  geometry
+  listings
+  xcolor
+  soul
+  # graphicx
+  fancyhdr
+  # array
+  amsmath
+  amsfonts
+  fancyvrb
+  # verbatim
+  longfbox
+  setspace
+  titlesec
+  hyperref
+  # subcaption
+  caption
+  colortbl
+  options
+  pict2e
+  ellipse
+)
+
+echo "Installing LaTeX packages via tlmgr..."
+
+for pkg in "${PACKAGES[@]}"; do
+  echo "Installing: $pkg"
+  tlmgr install "$pkg"
+done
+


### PR DESCRIPTION
I'm actually not sure if all `xelatex` users install via `tlmgr`. If this should be dealt with on case-by-case basis then it's fine to just close this pr.